### PR TITLE
chore: update readme to fix the yarn install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install the plugin:
 npm install --dev razzle-plugin-workbox
 
 # yarn
-npm add --dev razzle-plugin-workbox
+yarn add --dev razzle-plugin-workbox
 ```
 
 Add configuration to `razzle.config.js`:


### PR DESCRIPTION
The yarn instructions in the Readme say `npm add` instead of `yarn add`